### PR TITLE
`_bind()` method for `IIpv6Addresses`

### DIFF
--- a/packages/aws-cdk-lib/aws-ec2/lib/ip-addresses.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/ip-addresses.ts
@@ -140,6 +140,8 @@ export interface AllocateCidrRequest {
 
 /**
  * Internal interface to get VPC context to IpAddresses.
+ *
+ * @internal
  */
 export interface _VpcContext {
   /**

--- a/packages/aws-cdk-lib/aws-ec2/lib/ip-addresses.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/ip-addresses.ts
@@ -449,6 +449,8 @@ export class Ipv6Addresses {
 export interface IIpv6Addresses {
   /**
    * Internal function to get scope and context from VPC.
+   *
+   * @internal
    */
   _bind(context: _VpcContext): void;
 

--- a/packages/aws-cdk-lib/aws-ec2/lib/ip-addresses.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/ip-addresses.ts
@@ -448,7 +448,7 @@ export interface IIpv6Addresses {
   /**
    * Internal function to get scope and context from VPC.
    */
-  bind(context: _VpcContext): void;
+  _bind(context: _VpcContext): void;
 
   /**
    * Called by VPC to allocate IPv6 CIDR.
@@ -502,7 +502,7 @@ class AmazonProvided implements IIpv6Addresses {
    *
    * @internal
    */
-  bind(context: _VpcContext): void {
+  _bind(context: _VpcContext): void {
     this.scope = context.scope;
     this.vpcId = context.vpcId;
   }

--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
@@ -1594,7 +1594,7 @@ export class Vpc extends VpcBase {
     if (this.useIpv6) {
       this.ipv6Addresses = props.ipv6Addresses ?? Ipv6Addresses.amazonProvided();
 
-      this.ipv6Addresses.bind({
+      this.ipv6Addresses._bind({
         scope: this,
         vpcId: this.vpcId,
       });

--- a/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
+++ b/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
@@ -1594,10 +1594,12 @@ export class Vpc extends VpcBase {
     if (this.useIpv6) {
       this.ipv6Addresses = props.ipv6Addresses ?? Ipv6Addresses.amazonProvided();
 
-      this.ipv6CidrBlock = this.ipv6Addresses.allocateVpcIpv6Cidr({
+      this.ipv6Addresses.bind({
         scope: this,
         vpcId: this.vpcId,
       });
+
+      this.ipv6CidrBlock = this.ipv6Addresses.allocateVpcIpv6Cidr();
 
       this.ipv6SelectedCidr = Fn.select(0, this.resource.attrIpv6CidrBlocks);
     }


### PR DESCRIPTION
Currently, `IIpv6Addresses.allocateVpcIpv6Cidr()` takes arguments to pass the scope of the VPC construct and the `vpcId`. These are needed to create a `CfnVPCCidrBlock`. However, passing this context in separately through a `_bind()` method allows `allocateVpcIpv6Cidr()` to need no arguments, making its implementation flexible and extensible for each class that implements `IIpv6Addresses`.

Still a couple design decisions I would like consulting on:

- `bind()` or `_bind()`
  - along with generally needing the _ in names
- should `bind()` take the context variables as input, or should the context variables be non-constant and set
  - or `bind()` could call a private constructor where the context variables are directly set. This would avoid optional class variables and undefined checks

Tested the integ tests locally, and they succeed.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
